### PR TITLE
Add missing dependencies on gencpp

### DIFF
--- a/nav2d_navigator/CMakeLists.txt
+++ b/nav2d_navigator/CMakeLists.txt
@@ -75,6 +75,10 @@ add_executable(get_map_client src/get_map_client.cpp)
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
 add_dependencies(RobotNavigator nav2d_navigator_generate_messages_cpp)
+add_dependencies(navigator nav2d_navigator_generate_messages_cpp)
+add_dependencies(set_goal_client nav2d_navigator_generate_messages_cpp)
+add_dependencies(explore_client nav2d_navigator_generate_messages_cpp)
+add_dependencies(get_map_client nav2d_navigator_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(RobotNavigator MapInflationTool ${catkin_LIBRARIES})


### PR DESCRIPTION
These targets all include message headers at one point or another.

It is not uncommon for this type of error to not surface until compiled on a highly threaded machine (such as the RPM buildfarm machines). This error could, however, happen to anyone (depending on how the stars are aligned) and should be fixed.

Please backport to Hydro as well.

Example of breakage: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-nav2d-navigator_binaryrpm_heisenbug_i386/4/console

Thanks,

--scott
