### PR TITLE
fixed spa2d.h:163 from 'const' to 'constexpr' for variable qScale

### DIFF
--- a/nav2d_karto/include/nav2d_karto/spa2d.h
+++ b/nav2d_karto/include/nav2d_karto/spa2d.h
@@ -163,7 +163,7 @@
 
     /// scaling factor for quaternion derivatives relative to translational ones;
     /// not sure if this is needed, it's close to 1.0
-    const static double qScale = 1.0;
+    constexpr static double qScale = 1.0;
 
     /// dpc/dq = dR'/dq [pw-t], in homogeneous form, with q a quaternion param
     /// 


### PR DESCRIPTION
An error on this file cause abort compilation on my machine, running ROS Lunar, Ubuntu 17.04 x64